### PR TITLE
Implement global dark mode with user preference

### DIFF
--- a/DARK_MODE_IMPLEMENTATION.md
+++ b/DARK_MODE_IMPLEMENTATION.md
@@ -1,0 +1,98 @@
+# Dark Mode Implementation
+
+## Overview
+
+The dark mode implementation has been successfully updated to work across all pages of the website with proper state persistence.
+
+## Key Features
+
+### ✅ **Cross-Page Compatibility**
+- Dark mode now works on all pages: main (`/`), studio (`/studio`), content pages (`/content/[category]/[slug]`), and theme demo (`/theme-demo`)
+- All pages use consistent theme-aware CSS classes instead of hardcoded colors
+
+### ✅ **State Persistence**
+- User's theme preference is automatically saved to localStorage using `next-themes`
+- Theme preference persists across browser sessions and page navigation
+- Supports three modes: Light, Dark, and System (follows OS preference)
+
+### ✅ **Consistent Navigation**
+- All pages now include a unified Navigation component with theme toggle
+- Theme toggle is accessible from every page in the top navigation
+
+## Technical Implementation
+
+### Architecture
+1. **Theme Provider**: Uses `next-themes` library with proper configuration in root layout
+2. **CSS Variables**: All styling uses CSS variables that automatically change based on theme
+3. **Shared Navigation**: Consistent navigation component across all pages
+4. **Theme Toggle**: Available on all pages with three-state cycling (Light → Dark → System → Light)
+
+### Key Components
+
+#### 1. Navigation Component (`components/navigation.tsx`)
+- Unified navigation bar with theme toggle
+- Used across all pages for consistency
+- Shows current page state
+
+#### 2. Theme Provider (`components/theme-provider.tsx`)
+- Wraps the entire app in root layout
+- Configured with:
+  - `attribute="class"` - Uses CSS classes for theme switching
+  - `defaultTheme="system"` - Defaults to system preference
+  - `enableSystem` - Supports system theme detection
+  - `disableTransitionOnChange` - Prevents flash during SSR
+
+#### 3. Theme Toggle (`components/theme-toggle.tsx`)
+- Provides both dropdown and switch variants
+- Handles SSR hydration properly
+- Cycles through Light → Dark → System modes
+
+### CSS Implementation
+
+#### Global CSS Variables (`app/globals.css`)
+- Light and dark theme variables defined
+- CSS classes like `.bg-pattern`, `.bg-grid`, `.gradient-accent` adapt to theme
+- Uses semantic color tokens: `bg-background`, `text-foreground`, `text-muted-foreground`
+
+#### Before vs After
+
+**Before (Hardcoded Dark):**
+```tsx
+<div className="min-h-screen bg-zinc-950 text-zinc-100">
+  <span className="text-zinc-300">Content</span>
+</div>
+```
+
+**After (Theme-Aware):**
+```tsx
+<div className="min-h-screen bg-background text-foreground bg-pattern bg-grid">
+  <span className="text-muted-foreground">Content</span>
+</div>
+```
+
+## Pages Updated
+
+1. **Main Page** (`app/page.tsx`) - ✅ Updated to use Navigation component
+2. **Studio Page** (`app/studio/page.tsx`) - ✅ Converted from hardcoded dark to theme-aware
+3. **Content Pages** (`app/content/[category]/[slug]/page.tsx`) - ✅ Converted from hardcoded dark to theme-aware  
+4. **Theme Demo Page** (`app/theme-demo/page.tsx`) - ✅ Added Navigation component
+
+## Testing
+
+The implementation has been tested and verified:
+- ✅ Development server runs successfully
+- ✅ All pages render correctly with theme support
+- ✅ Theme toggle appears on all pages
+- ✅ CSS variables are properly applied
+- ✅ next-themes script is included in HTML output
+- ✅ Theme persistence is handled by next-themes library
+
+## Usage
+
+Users can now:
+1. Toggle between Light/Dark/System modes from any page
+2. Have their preference remembered across sessions
+3. Enjoy consistent theming across the entire website
+4. Benefit from automatic system theme detection
+
+The dark mode implementation is now complete and fully functional across all pages!

--- a/app/content/[category]/[slug]/page.tsx
+++ b/app/content/[category]/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { ArrowLeft } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Navigation } from "@/components/navigation"
 import { getContentItem } from "@/lib/content"
 import { redirect } from "next/navigation"
 import { notFound } from "next/navigation"
@@ -25,19 +26,12 @@ export default async function ContentPage({ params }: ContentPageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
-      <div className="max-w-2xl mx-auto px-6 py-12">
+    <div className="min-h-screen bg-background text-foreground bg-pattern bg-grid">
+      <div className="max-w-2xl mx-auto px-6 py-12 relative">
+        <div className="gradient-accent absolute inset-0 -z-10"></div>
+
         {/* Navigation */}
-        <nav className="flex items-center justify-between mb-16">
-          <Link href="/" className="text-lg font-medium font-heading">
-            Main
-          </Link>
-          <div className="flex items-center gap-8">
-            <Link href="/studio" className="text-zinc-300 hover:text-zinc-100 transition-colors">
-              Studio
-            </Link>
-          </div>
-        </nav>
+        <Navigation currentPage="studio" />
 
         {/* Back Button */}
         <Button variant="ghost" size="sm" className="mb-8 -ml-2" asChild>
@@ -53,7 +47,7 @@ export default async function ContentPage({ params }: ContentPageProps) {
             <h1 className="text-4xl md:text-5xl font-bold mb-4 leading-tight font-heading">
               {item.title}
             </h1>
-            <time className="text-zinc-300 font-body" dateTime={item.date}>
+            <time className="text-muted-foreground font-body" dateTime={item.date}>
               {new Date(item.date).toLocaleDateString('en-US', {
                 year: 'numeric',
                 month: 'long',
@@ -62,14 +56,14 @@ export default async function ContentPage({ params }: ContentPageProps) {
             </time>
           </header>
 
-          <div className="prose prose-invert prose-zinc max-w-none">
+          <div className="prose prose-invert prose-zinc max-w-none dark:prose-invert">
             {item.htmlContent ? (
               <div
-                className="text-zinc-300 leading-relaxed font-body [&>*]:mb-6 [&>h1]:text-3xl [&>h1]:font-semibold [&>h1]:text-zinc-100 [&>h1]:mt-12 [&>h1]:mb-6 [&>h1]:font-heading [&>h2]:text-2xl [&>h2]:font-semibold [&>h2]:text-zinc-100 [&>h2]:mt-12 [&>h2]:mb-6 [&>h2]:font-heading [&>h3]:text-xl [&>h3]:font-semibold [&>h3]:text-zinc-100 [&>h3]:mt-8 [&>h3]:mb-4 [&>h3]:font-heading [&>p]:leading-relaxed [&>ul]:list-disc [&>ul]:pl-6 [&>ol]:list-decimal [&>ol]:pl-6 [&>li]:mb-2 [&>blockquote]:border-l-4 [&>blockquote]:border-zinc-600 [&>blockquote]:pl-4 [&>blockquote]:italic [&>blockquote]:text-zinc-300 [&>code]:bg-zinc-800 [&>code]:px-2 [&>code]:py-1 [&>code]:rounded [&>code]:text-sm [&>pre]:bg-zinc-800 [&>pre]:p-4 [&>pre]:rounded [&>pre]:overflow-x-auto [&>pre]:text-sm"
+                className="text-muted-foreground leading-relaxed font-body [&>*]:mb-6 [&>h1]:text-3xl [&>h1]:font-semibold [&>h1]:text-foreground [&>h1]:mt-12 [&>h1]:mb-6 [&>h1]:font-heading [&>h2]:text-2xl [&>h2]:font-semibold [&>h2]:text-foreground [&>h2]:mt-12 [&>h2]:mb-6 [&>h2]:font-heading [&>h3]:text-xl [&>h3]:font-semibold [&>h3]:text-foreground [&>h3]:mt-8 [&>h3]:mb-4 [&>h3]:font-heading [&>p]:leading-relaxed [&>ul]:list-disc [&>ul]:pl-6 [&>ol]:list-decimal [&>ol]:pl-6 [&>li]:mb-2 [&>blockquote]:border-l-4 [&>blockquote]:border-border [&>blockquote]:pl-4 [&>blockquote]:italic [&>blockquote]:text-muted-foreground [&>code]:bg-muted [&>code]:px-2 [&>code]:py-1 [&>code]:rounded [&>code]:text-sm [&>pre]:bg-muted [&>pre]:p-4 [&>pre]:rounded [&>pre]:overflow-x-auto [&>pre]:text-sm"
                 dangerouslySetInnerHTML={{ __html: item.htmlContent }}
               />
             ) : (
-              <p className="text-zinc-300 leading-relaxed font-body">
+              <p className="text-muted-foreground leading-relaxed font-body">
                 Content not available.
               </p>
             )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link"
 import { Github, Twitter, Mail, Linkedin } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { ThemeToggle } from "@/components/theme-toggle"
+import { Navigation } from "@/components/navigation"
 import { getRecentItems } from "@/lib/content"
 
 export default async function HomePage() {
@@ -13,17 +13,7 @@ export default async function HomePage() {
         <div className="gradient-accent absolute inset-0 -z-10"></div>
 
         {/* Navigation */}
-        <nav className="flex items-center justify-between mb-12">
-          <Link href="/" className="text-lg font-medium font-heading">
-            Main
-          </Link>
-          <div className="flex items-center gap-8">
-            <Link href="/studio" className="text-muted-foreground hover:text-foreground transition-colors">
-              Studio
-            </Link>
-            <ThemeToggle />
-          </div>
-        </nav>
+        <Navigation currentPage="main" />
 
         {/* Hero Section */}
         <section className="mb-12">

--- a/app/studio/page.tsx
+++ b/app/studio/page.tsx
@@ -1,31 +1,23 @@
 import Link from "next/link"
+import { Navigation } from "@/components/navigation"
 import { getContentStructure } from "@/lib/content"
 
 export default async function StudioPage() {
   const contentSections = await getContentStructure()
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100 bg-pattern bg-grid">
+    <div className="min-h-screen bg-background text-foreground bg-pattern bg-grid">
       <div className="max-w-2xl mx-auto px-6 py-12 relative">
         <div className="gradient-accent absolute inset-0 -z-10"></div>
 
         {/* Navigation */}
-        <nav className="flex items-center justify-between mb-16">
-          <Link href="/" className="text-lg font-medium font-heading">
-            Main
-          </Link>
-          <div className="flex items-center gap-8">
-            <Link href="/studio" className="text-zinc-100 font-medium">
-              Studio
-            </Link>
-          </div>
-        </nav>
+        <Navigation currentPage="studio" />
 
         {/* Dynamic Content Sections */}
         {contentSections.length === 0 ? (
           <div className="text-center py-16">
-            <h2 className="text-2xl font-semibold mb-4 font-heading text-zinc-300">No Content Yet</h2>
-            <p className="text-zinc-400 font-body">
+            <h2 className="text-2xl font-semibold mb-4 font-heading text-muted-foreground">No Content Yet</h2>
+            <p className="text-muted-foreground font-body">
               Create folders in the content directory and add markdown files to see them here.
             </p>
           </div>
@@ -42,7 +34,7 @@ export default async function StudioPage() {
                       {item.external_url ? (
                         <Link
                           href={item.external_url}
-                          className="text-zinc-300 hover:text-zinc-100 transition-colors font-body"
+                          className="text-muted-foreground hover:text-foreground transition-colors font-body"
                           target="_blank"
                           rel="noopener noreferrer"
                         >
@@ -51,12 +43,12 @@ export default async function StudioPage() {
                       ) : (
                         <Link
                           href={`/content/${item.category}/${item.slug}`}
-                          className="text-zinc-300 hover:text-zinc-100 transition-colors font-body"
+                          className="text-muted-foreground hover:text-foreground transition-colors font-body"
                         >
                           {item.title}
                         </Link>
                       )}
-                      <span className="text-sm text-zinc-400 font-body">
+                      <span className="text-sm text-muted-foreground font-body">
                         {new Date(item.date).toLocaleDateString('en-US', {
                           year: 'numeric',
                           month: '2-digit'

--- a/app/theme-demo/page.tsx
+++ b/app/theme-demo/page.tsx
@@ -1,9 +1,17 @@
+import { Navigation } from "@/components/navigation"
 import { ThemeDemo } from "@/components/theme-demo"
 
 export default function ThemeDemoPage() {
   return (
-    <main className="min-h-screen bg-background">
-      <ThemeDemo />
-    </main>
+    <div className="min-h-screen bg-background text-foreground bg-pattern bg-grid">
+      <div className="max-w-2xl mx-auto px-6 py-12 relative">
+        <div className="gradient-accent absolute inset-0 -z-10"></div>
+        
+        {/* Navigation */}
+        <Navigation />
+        
+        <ThemeDemo />
+      </div>
+    </div>
   )
 }

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import Link from "next/link"
+import { ThemeToggle } from "@/components/theme-toggle"
+
+interface NavigationProps {
+  currentPage?: "main" | "studio"
+}
+
+export function Navigation({ currentPage = "main" }: NavigationProps) {
+  return (
+    <nav className="flex items-center justify-between mb-12">
+      <Link href="/" className="text-lg font-medium font-heading">
+        Main
+      </Link>
+      <div className="flex items-center gap-8">
+        <Link 
+          href="/studio" 
+          className={
+            currentPage === "studio" 
+              ? "text-foreground font-medium" 
+              : "text-muted-foreground hover:text-foreground transition-colors"
+          }
+        >
+          Studio
+        </Link>
+        <ThemeToggle />
+      </div>
+    </nav>
+  )
+}


### PR DESCRIPTION
Implement site-wide dark mode with state persistence to ensure consistent theming across all pages.

The existing dark mode was limited to the main page, with other pages having hardcoded dark styles and no theme toggle. This PR unifies the theme implementation by introducing a shared navigation component with the theme toggle and replacing hardcoded styles with theme-aware CSS variables, leveraging the existing `next-themes` setup for persistence.